### PR TITLE
Fixed og:image properties for issue #76

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -58,15 +58,15 @@
 	<meta content="GDG" name="twitter:site">
 	<meta content="GDG JSS NOIDA" name="twitter:title">
 	<meta content="Google Developer Groups are for developers who are interested in Google's developer technology." name="twitter:description">
-	<meta content="/img/seo/sharing-twitter.png" name="twitter:image:src">
+	<meta content="/img/favicons/favicon.ico" name="twitter:image:src">
 	<!-- Social: Facebook / Open Graph -->
 	<meta content="GDG JSS NOIDA" property="og:title">
 	<meta content="GDG JSS NOIDA" property="og:site_name">
 	<meta content="website" property="og:type">
 	<meta content="http://gdgjss.in" property="og:url">
-	<meta content="/img/seo/sharing-facebook.png" property="og:image">
 	<meta content="Google Developer Groups are for developers who are interested in Google's developer technology." property="og:description">
-
+	<meta content="/img/favicons/favicon.ico" property="og:image">
+	
 	<title>GDG JSS NOIDA</title>
 	<link href="/img/favicons/favicon.ico" rel="shortcut icon">
 	<link href="/img/favicons/apple-touch-icon-152x152.png" rel="apple-touch-icon" sizes="152x152">


### PR DESCRIPTION
Meta `og:image` in `index.html` was not showing because it was referring to a non-existent directory. Changed meta image to the favicon. Resolves issue #76 